### PR TITLE
Add `StartupWMClass` to the desktop file

### DIFF
--- a/stuntcarracer.desktop
+++ b/stuntcarracer.desktop
@@ -4,5 +4,6 @@ Name=Stunt Car Remake
 Comment=Remake of the old game Stunt Car Racer
 Exec=stuntcarracer
 Icon=stuntcarracer
+StartupWMClass=stuntcarracer
 Categories=Game;Simulation;
 


### PR DESCRIPTION
This resolves edge-cases where desktop icon is not shown, like in Gnome's dash for example.